### PR TITLE
use context

### DIFF
--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -1,6 +1,8 @@
 package stannp
 
 import (
+	"context"
+
 	"github.com/CopilotIQ/stannp-client-golang/address"
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/CopilotIQ/stannp-client-golang/util"
@@ -8,8 +10,8 @@ import (
 
 // Client interface is for mocking / testing. Implement it however you wish!
 type Client interface {
-	SendLetter(request *letter.SendReq) (*letter.SendRes, *util.APIError)
-	ValidateAddress(request *address.ValidateReq) (*address.ValidateRes, *util.APIError)
+	SendLetter(ctx context.Context, request *letter.SendReq) (*letter.SendRes, *util.APIError)
+	ValidateAddress(ctx context.Context, request *address.ValidateReq) (*address.ValidateRes, *util.APIError)
 }
 
 type MockOption func(*MockClient)
@@ -21,6 +23,8 @@ type MockClient struct {
 	addressFailNext bool
 	letterFailNext  bool
 }
+
+var _ Client = (*MockClient)(nil)
 
 func WithAddressFailNext(failNext bool) MockOption {
 	return func(c *MockClient) {
@@ -62,7 +66,7 @@ func NewMockClient(opts ...MockOption) *MockClient {
 	return client
 }
 
-func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIError) {
+func (mc *MockClient) SendLetter(_ context.Context, _ *letter.SendReq) (*letter.SendRes, *util.APIError) {
 	if mc.letterFailNext {
 		apiErr := &util.APIError{
 			Code:    500,
@@ -94,7 +98,7 @@ func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIE
 	}, nil
 }
 
-func (mc *MockClient) ValidateAddress(_ *address.ValidateReq) (*address.ValidateRes, *util.APIError) {
+func (mc *MockClient) ValidateAddress(_ context.Context, _ *address.ValidateReq) (*address.ValidateRes, *util.APIError) {
 	if mc.addressFailNext {
 		apiErr := &util.APIError{
 			Code:    500,

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -1,12 +1,14 @@
 package stannp
 
 import (
+	"context"
+	"reflect"
+	"testing"
+
 	"github.com/CopilotIQ/stannp-client-golang/address"
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/CopilotIQ/stannp-client-golang/util"
 	"github.com/jgroeneveld/trial/assert"
-	"reflect"
-	"testing"
 )
 
 func TestNewMockClient(t *testing.T) {
@@ -123,7 +125,7 @@ func TestMockSendLetter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := NewMockClient(tt.mockClientOptions...)
-			sendLetterRes, apiErr := mockClient.SendLetter(&letter.SendReq{})
+			sendLetterRes, apiErr := mockClient.SendLetter(context.Background(), &letter.SendReq{})
 
 			if tt.expectedError != nil {
 				assert.NotNil(t, apiErr)
@@ -194,7 +196,7 @@ func TestMockValidateAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := NewMockClient(tt.mockClientOptions...)
-			validateAddressRes, apiErr := mockClient.ValidateAddress(&address.ValidateReq{})
+			validateAddressRes, apiErr := mockClient.ValidateAddress(context.Background(), &address.ValidateReq{})
 
 			if tt.errExpected != nil {
 				assert.NotNil(t, apiErr)

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -1,15 +1,17 @@
 package stannp
 
 import (
-	"github.com/CopilotIQ/stannp-client-golang/address"
-	"github.com/CopilotIQ/stannp-client-golang/letter"
-	"github.com/jgroeneveld/trial/assert"
-	"github.com/joho/godotenv"
+	"context"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/CopilotIQ/stannp-client-golang/address"
+	"github.com/CopilotIQ/stannp-client-golang/letter"
+	"github.com/jgroeneveld/trial/assert"
+	"github.com/joho/godotenv"
 )
 
 const ApiKeyEnvKey = "STANNP_API_KEY"
@@ -100,7 +102,7 @@ func TestSendLetter(t *testing.T) {
 	}
 
 	// Note: This call is not actually sending a request.
-	response, apiErr := TestClient.SendLetter(request)
+	response, apiErr := TestClient.SendLetter(context.Background(), request)
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 
 	assert.True(t, response.Success)
@@ -121,7 +123,7 @@ func TestValidateAddress(t *testing.T) {
 			Zipcode:  "90210",
 		}
 
-		validateRes, apiErr := TestClient.ValidateAddress(request)
+		validateRes, apiErr := TestClient.ValidateAddress(context.Background(), request)
 		assert.True(t, reflect.ValueOf(apiErr).IsNil())
 		assert.False(t, validateRes.Data.IsValid)
 		assert.True(t, validateRes.Success)
@@ -136,7 +138,7 @@ func TestValidateAddress(t *testing.T) {
 			Zipcode:  "90210",
 		}
 
-		validateRes, apiErr := TestClient.ValidateAddress(request)
+		validateRes, apiErr := TestClient.ValidateAddress(context.Background(), request)
 		assert.True(t, reflect.ValueOf(apiErr).IsNil())
 		assert.True(t, validateRes.Data.IsValid)
 		assert.True(t, validateRes.Success)


### PR DESCRIPTION
pass context through to the http request so that cancellations can be properly propagated.