### PR TITLE
allow custom http client

### DIFF
--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -2,16 +2,17 @@ package stannp
 
 import (
 	"fmt"
-	"github.com/CopilotIQ/stannp-client-golang/address"
-	"github.com/CopilotIQ/stannp-client-golang/letter"
-	"github.com/CopilotIQ/stannp-client-golang/util"
-	"github.com/google/uuid"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/CopilotIQ/stannp-client-golang/address"
+	"github.com/CopilotIQ/stannp-client-golang/letter"
+	"github.com/CopilotIQ/stannp-client-golang/util"
+	"github.com/google/uuid"
 )
 
 const BaseURL = "https://us.stannp.com/api/v1"
@@ -75,6 +76,12 @@ func WithDuplex(duplex bool) APIOption {
 func WithIdempotencyFunc(f IdempotencyFunc) APIOption {
 	return func(s *Stannp) {
 		s.idemFunc = f
+	}
+}
+
+func WithHTTPClient(hc *http.Client) APIOption {
+	return func(s *Stannp) {
+		s.client = hc
 	}
 }
 


### PR DESCRIPTION
Allow callers to provide a custom http client. This is important for any level of customization that can occur on the http client including specifying timeouts, tracing, etc..