### PR TITLE
[#4] Update Stannp response id from string to int

### DIFF
--- a/letter/letter.go
+++ b/letter/letter.go
@@ -26,7 +26,7 @@ type Data struct {
 	Cost    string `json:"cost"`
 	Created string `json:"created"`
 	Format  string `json:"format"`
-	Id      string `json:"id"`
+	Id      int    `json:"id"`
 	Pdf     string `json:"pdf"`
 	Status  string `json:"status"`
 }

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -86,7 +86,7 @@ func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIE
 			Cost:    util.RandomString(10),
 			Created: util.RandomString(10),
 			Format:  util.RandomString(10),
-			Id:      util.RandomString(10),
+			Id:      0,
 			Pdf:     util.RandomString(10),
 			Status:  "received",
 		},

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -138,7 +138,7 @@ func TestMockSendLetter(t *testing.T) {
 				assert.True(t, sendLetterRes.Data.Cost != "")
 				assert.True(t, sendLetterRes.Data.Created != "")
 				assert.True(t, sendLetterRes.Data.Format != "")
-				assert.True(t, sendLetterRes.Data.Id != "")
+				assert.True(t, sendLetterRes.Data.Id == 0)
 				assert.True(t, sendLetterRes.Data.Pdf != "")
 				assert.True(t, sendLetterRes.Data.Status != "")
 			}

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 func TestSendLetter(t *testing.T) {
 	// Call SendLetter with a new instance of SendReq
 	request := &letter.SendReq{
-		Template: "305202",
+		Template: "307051",
 		Recipient: letter.RecipientDetails{
 			Address1:  "9355 Burton Way",
 			Address2:  "Courthouse",


### PR DESCRIPTION
## Issue
#4 

## Summary of Changes
- Changes `id` from string to int in Stannp response
- Updates a template ID in tests, seems this was returning `success:false` from Stannp

## Tests
<details>
<summary>Tests passed</summary>

```
zach@zachs-mbp stannp-client-golang % make test
go test -v ./...
?       github.com/CopilotIQ/stannp-client-golang/address       [no test files]
?       github.com/CopilotIQ/stannp-client-golang/letter        [no test files]
=== RUN   TestNewMockClient
=== RUN   TestNewMockClient/no_options
=== RUN   TestNewMockClient/with_addressFailNext
=== RUN   TestNewMockClient/with_letterFailNext
=== RUN   TestNewMockClient/with_invalidNext
=== RUN   TestNewMockClient/with_codeNext
=== RUN   TestNewMockClient/with_errNext
=== RUN   TestNewMockClient/with_all_options
--- PASS: TestNewMockClient (0.00s)
    --- PASS: TestNewMockClient/no_options (0.00s)
    --- PASS: TestNewMockClient/with_addressFailNext (0.00s)
    --- PASS: TestNewMockClient/with_letterFailNext (0.00s)
    --- PASS: TestNewMockClient/with_invalidNext (0.00s)
    --- PASS: TestNewMockClient/with_codeNext (0.00s)
    --- PASS: TestNewMockClient/with_errNext (0.00s)
    --- PASS: TestNewMockClient/with_all_options (0.00s)
=== RUN   TestMockSendLetter
=== RUN   TestMockSendLetter/success_expected_err_not_expected
=== RUN   TestMockSendLetter/success_not_expected_err_expected
=== RUN   TestMockSendLetter/err_expected_code_expected_custom_err_expected
--- PASS: TestMockSendLetter (0.00s)
    --- PASS: TestMockSendLetter/success_expected_err_not_expected (0.00s)
    --- PASS: TestMockSendLetter/success_not_expected_err_expected (0.00s)
    --- PASS: TestMockSendLetter/err_expected_code_expected_custom_err_expected (0.00s)
=== RUN   TestMockValidateAddress
=== RUN   TestMockValidateAddress/valid_expected_err_not_expected
=== RUN   TestMockValidateAddress/valid_not_expected_err_not_expected
=== RUN   TestMockValidateAddress/err_expected
=== RUN   TestMockValidateAddress/fail_next_code_next_err_next
--- PASS: TestMockValidateAddress (0.00s)
    --- PASS: TestMockValidateAddress/valid_expected_err_not_expected (0.00s)
    --- PASS: TestMockValidateAddress/valid_not_expected_err_not_expected (0.00s)
    --- PASS: TestMockValidateAddress/err_expected (0.00s)
    --- PASS: TestMockValidateAddress/fail_next_code_next_err_next (0.00s)
=== RUN   TestInterface
--- PASS: TestInterface (0.00s)
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestSendLetter
--- PASS: TestSendLetter (2.53s)
=== RUN   TestValidateAddress
=== RUN   TestValidateAddress/verify_is_valid_is_false_for_fake_data
=== RUN   TestValidateAddress/verify_is_valid_is_true_for_real_data
--- PASS: TestValidateAddress (2.48s)
    --- PASS: TestValidateAddress/verify_is_valid_is_false_for_fake_data (1.26s)
    --- PASS: TestValidateAddress/verify_is_valid_is_true_for_real_data (1.22s)
PASS
ok      github.com/CopilotIQ/stannp-client-golang/stannp        5.202s
?       github.com/CopilotIQ/stannp-client-golang/util  [no test files]
```
</details>