### PR TITLE
switch from int to json.number and increase test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: format build test
+
 build:
 	go build -ldflags="-s -w" ./...
 

--- a/letter/letter.go
+++ b/letter/letter.go
@@ -1,5 +1,7 @@
 package letter
 
+import "encoding/json"
+
 const URL = "letters"
 
 type RecipientDetails struct {
@@ -23,12 +25,12 @@ type SendReq struct {
 }
 
 type Data struct {
-	Cost    string `json:"cost"`
-	Created string `json:"created"`
-	Format  string `json:"format"`
-	Id      int    `json:"id"`
-	Pdf     string `json:"pdf"`
-	Status  string `json:"status"`
+	Cost    string      `json:"cost"`
+	Created string      `json:"created"`
+	Format  string      `json:"format"`
+	Id      json.Number `json:"id"`
+	Pdf     string      `json:"pdf"`
+	Status  string      `json:"status"`
 }
 
 type SendRes struct {

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -86,7 +86,7 @@ func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIE
 			Cost:    util.RandomString(10),
 			Created: util.RandomString(10),
 			Format:  util.RandomString(10),
-			Id:      0,
+			Id:      "0",
 			Pdf:     util.RandomString(10),
 			Status:  "received",
 		},

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -138,7 +138,7 @@ func TestMockSendLetter(t *testing.T) {
 				assert.True(t, sendLetterRes.Data.Cost != "")
 				assert.True(t, sendLetterRes.Data.Created != "")
 				assert.True(t, sendLetterRes.Data.Format != "")
-				assert.True(t, sendLetterRes.Data.Id == 0)
+				assert.True(t, sendLetterRes.Data.Id == "0")
 				assert.True(t, sendLetterRes.Data.Pdf != "")
 				assert.True(t, sendLetterRes.Data.Status != "")
 			}

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -1,6 +1,7 @@
 package stannp
 
 import (
+	"encoding/json"
 	"github.com/CopilotIQ/stannp-client-golang/address"
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/jgroeneveld/trial/assert"
@@ -145,5 +146,53 @@ func TestValidateAddress(t *testing.T) {
 		assert.True(t, reflect.ValueOf(apiErr).IsNil())
 		assert.True(t, validateRes.Data.IsValid)
 		assert.True(t, validateRes.Success)
+	})
+}
+
+func TestJSONValuesUnmarshalWithCorrectFlexibility(t *testing.T) {
+	t.Run("verify when Id is an int", func(t *testing.T) {
+		rawJSON := `
+{
+  "data": {
+    "cost": "10.99",
+    "created": "2023-06-22",
+    "format": "A4",
+    "id": 12345,
+    "pdf": "https://example.com/document.pdf",
+    "status": "completed"
+  },
+  "success": true
+}`
+		var letterRes letter.SendRes
+		jsonErr := json.Unmarshal([]byte(rawJSON), &letterRes)
+		assert.Nil(t, jsonErr)
+
+		int64Val, err := letterRes.Data.Id.Int64()
+		assert.Nil(t, err)
+		assert.Equal(t, "12345", letterRes.Data.Id.String())
+		assert.Equal(t, int64(12345), int64Val)
+	})
+	t.Run("verify when Id is a string", func(t *testing.T) {
+		rawJSON := `
+{
+  "data": {
+    "cost": "10.99",
+    "created": "2023-06-22",
+    "format": "A4",
+    "id": "12345",
+    "pdf": "https://example.com/document.pdf",
+    "status": "completed"
+  },
+  "success": true
+}`
+
+		var letterRes letter.SendRes
+		jsonErr := json.Unmarshal([]byte(rawJSON), &letterRes)
+		assert.Nil(t, jsonErr)
+
+		int64Val, err := letterRes.Data.Id.Int64()
+		assert.Nil(t, err)
+		assert.Equal(t, "12345", letterRes.Data.Id.String())
+		assert.Equal(t, int64(12345), int64Val)
 	})
 }

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 const ApiKeyEnvKey = "STANNP_API_KEY"
@@ -103,10 +104,14 @@ func TestSendLetter(t *testing.T) {
 	response, apiErr := TestClient.SendLetter(request)
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 
+	dateString := time.Now().Format("2006-01-02")
+
+	assert.Equal(t, response.Data.Cost, "0.81")
+	assert.Equal(t, response.Data.Format, "US-LETTER")
+	assert.Equal(t, response.Data.Id.String(), "0")
+	assert.Equal(t, response.Data.Status, "test")
 	assert.True(t, response.Success)
-	assert.Equal(t, "0.81", response.Data.Cost)
-	assert.Equal(t, "US-LETTER", response.Data.Format)
-	assert.Equal(t, "test", response.Data.Status)
+	assert.True(t, strings.HasPrefix(response.Data.Created, dateString))
 	assert.True(t, strings.HasPrefix(response.Data.Pdf, "https://us.stannp.com/api/v1/storage/get/"))
 }
 


### PR DESCRIPTION
1. fixed an issue where "Created" was not checked against the API's returned value
2. fixed an issue where "Id" was not checked against the API's returned value
3. switched from `int` to `json.Number` to prevent further shenanigans from the stannp side

This will potentially create a small breaking changes on the copilotiq side however it won't be an issue as we're already in prod with the previous version and compile should break next time when we import the updated version number.

@dillonstreator