### PR TITLE
[ENG-2595] Implement pdf download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: format build test
+all: tidy format build test
 
 build:
 	go build -ldflags="-s -w" ./...
@@ -8,3 +8,6 @@ format:
 
 test:
 	go test -v ./...
+
+tidy:
+	go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,9 @@ module github.com/CopilotIQ/stannp-client-golang
 go 1.18
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/jgroeneveld/trial v2.0.0+incompatible
 	github.com/joho/godotenv v1.5.1
-	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 )
 
-require (
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/jgroeneveld/schema v1.0.0 // indirect
-)
+require github.com/jgroeneveld/schema v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,3 @@ github.com/jgroeneveld/trial v2.0.0+incompatible h1:d59ctdgor+VqdZCAiUfVN8K13s0A
 github.com/jgroeneveld/trial v2.0.0+incompatible/go.mod h1:I6INLW96EN8WysNBXUFI3M4RIC8ePg9ntAc/Wy+U/+M=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 h1:dOYG7LS/WK00RWZc8XGgcUTlTxpp3mKhdR2Q9z9HbXM=
-github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=

--- a/letter/letter.go
+++ b/letter/letter.go
@@ -1,6 +1,9 @@
 package letter
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"io"
+)
 
 const URL = "letters"
 
@@ -14,9 +17,8 @@ type Data struct {
 }
 
 type PDFRes struct {
-	Bytes []byte
-	Len   int
-	Name  string
+	Contents io.ReadCloser
+	Name     string
 }
 
 type RecipientDetails struct {

--- a/letter/letter.go
+++ b/letter/letter.go
@@ -4,6 +4,21 @@ import "encoding/json"
 
 const URL = "letters"
 
+type Data struct {
+	Cost    string      `json:"cost"`
+	Created string      `json:"created"`
+	Format  string      `json:"format"`
+	Id      json.Number `json:"id"`
+	PDF     string      `json:"pdf"`
+	Status  string      `json:"status"`
+}
+
+type PDFRes struct {
+	Bytes []byte
+	Len   int
+	Name  string
+}
+
 type RecipientDetails struct {
 	Address1  string `json:"address1"`
 	Address2  string `json:"address2"`
@@ -22,15 +37,6 @@ type SendReq struct {
 	MergeVariables MergeVariables   `json:"mergeVariables"`
 	Recipient      RecipientDetails `json:"recipient"`
 	Template       string           `json:"template"`
-}
-
-type Data struct {
-	Cost    string      `json:"cost"`
-	Created string      `json:"created"`
-	Format  string      `json:"format"`
-	Id      json.Number `json:"id"`
-	Pdf     string      `json:"pdf"`
-	Status  string      `json:"status"`
 }
 
 type SendRes struct {

--- a/letter/letter.go
+++ b/letter/letter.go
@@ -9,7 +9,7 @@ type Data struct {
 	Created string      `json:"created"`
 	Format  string      `json:"format"`
 	Id      json.Number `json:"id"`
-	PDF     string      `json:"pdf"`
+	PDFURL  string      `json:"pdf"`
 	Status  string      `json:"status"`
 }
 

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -139,7 +139,7 @@ func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIE
 			Created: util.RandomString(10),
 			Format:  util.RandomString(10),
 			Id:      "0",
-			PDF:     util.RandomString(10),
+			PDFURL:  util.RandomString(10),
 			Status:  "received",
 		},
 		Success: true,

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -26,7 +26,7 @@ type MockClient struct {
 	bytesToPDFFailNext  bool
 	codeNext            int
 	downloadPDFFailNext bool
-	errNext             string
+	errorMessageNext    string
 	invalidNext         bool
 	letterFailNext      bool
 }
@@ -57,9 +57,9 @@ func WithDownloadPDFFailNext(failNext bool) MockOption {
 	}
 }
 
-func WithErrNext(errNext string) MockOption {
+func WithErrorMessageNext(errNext string) MockOption {
 	return func(c *MockClient) {
-		c.errNext = errNext
+		c.errorMessageNext = errNext
 	}
 }
 
@@ -93,8 +93,8 @@ func (mc *MockClient) BytesToPDF(_ []byte) (*os.File, *util.APIError) {
 			apiErr.Code = mc.codeNext
 		}
 
-		if mc.errNext != "" {
-			apiErr.Error = mc.errNext
+		if mc.errorMessageNext != "" {
+			apiErr.ErrorMessage = mc.errorMessageNext
 		}
 
 		return nil, apiErr
@@ -110,8 +110,8 @@ func (mc *MockClient) GetPDFContents(_ context.Context, pdfURL string) (*letter.
 			apiErr.Code = mc.codeNext
 		}
 
-		if mc.errNext != "" {
-			apiErr.Error = mc.errNext
+		if mc.errorMessageNext != "" {
+			apiErr.ErrorMessage = mc.errorMessageNext
 		}
 
 		return nil, apiErr
@@ -131,8 +131,8 @@ func (mc *MockClient) SendLetter(_ context.Context, _ *letter.SendReq) (*letter.
 			apiErr.Code = mc.codeNext
 		}
 
-		if mc.errNext != "" {
-			apiErr.Error = mc.errNext
+		if mc.errorMessageNext != "" {
+			apiErr.ErrorMessage = mc.errorMessageNext
 		}
 
 		return nil, apiErr
@@ -159,8 +159,8 @@ func (mc *MockClient) ValidateAddress(_ context.Context, _ *address.ValidateReq)
 			apiErr.Code = mc.codeNext
 		}
 
-		if mc.errNext != "" {
-			apiErr.Error = mc.errNext
+		if mc.errorMessageNext != "" {
+			apiErr.ErrorMessage = mc.errorMessageNext
 		}
 
 		return nil, apiErr

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -14,7 +14,7 @@ import (
 // Client interface is for mocking / testing. Implement it however you wish!
 type Client interface {
 	GetPDFContents(ctx context.Context, pdfURL string) (*letter.PDFRes, *util.APIError)
-	SavePDFContents(pdfContents io.ReadCloser) (*os.File, *util.APIError)
+	SavePDFContents(pdfContents io.Reader) (*os.File, *util.APIError)
 	SendLetter(ctx context.Context, req *letter.SendReq) (*letter.SendRes, *util.APIError)
 	ValidateAddress(ctx context.Context, req *address.ValidateReq) (*address.ValidateRes, *util.APIError)
 }
@@ -106,7 +106,7 @@ func (mc *MockClient) GetPDFContents(_ context.Context, pdfURL string) (*letter.
 	}, nil
 }
 
-func (mc *MockClient) SavePDFContents(_ io.ReadCloser) (*os.File, *util.APIError) {
+func (mc *MockClient) SavePDFContents(_ io.Reader) (*os.File, *util.APIError) {
 	if mc.bytesToPDFFailNext {
 		apiErr := util.BuildError(500, "bytesToPDFFailNext is true")
 

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -13,10 +13,10 @@ import (
 
 // Client interface is for mocking / testing. Implement it however you wish!
 type Client interface {
-	GetPDFContents(ctx context.Context, urlInput string) (*letter.PDFRes, *util.APIError)
+	GetPDFContents(ctx context.Context, pdfURL string) (*letter.PDFRes, *util.APIError)
 	SavePDFContents(pdfContents io.ReadCloser) (*os.File, *util.APIError)
-	SendLetter(ctx context.Context, request *letter.SendReq) (*letter.SendRes, *util.APIError)
-	ValidateAddress(ctx context.Context, request *address.ValidateReq) (*address.ValidateRes, *util.APIError)
+	SendLetter(ctx context.Context, req *letter.SendReq) (*letter.SendRes, *util.APIError)
+	ValidateAddress(ctx context.Context, req *address.ValidateReq) (*address.ValidateRes, *util.APIError)
 }
 
 type MockOption func(*MockClient)

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -1,7 +1,9 @@
 package stannp
 
 import (
+	"bytes"
 	"context"
+	"io"
 
 	"github.com/CopilotIQ/stannp-client-golang/address"
 	"github.com/CopilotIQ/stannp-client-golang/letter"
@@ -12,7 +14,7 @@ import (
 // Client interface is for mocking / testing. Implement it however you wish!
 type Client interface {
 	BytesToPDF(data []byte) (*os.File, *util.APIError)
-	DownloadPDF(ctx context.Context, urlInput string) (*letter.PDFRes, *util.APIError)
+	GetPDFContents(ctx context.Context, urlInput string) (*letter.PDFRes, *util.APIError)
 	SendLetter(ctx context.Context, request *letter.SendReq) (*letter.SendRes, *util.APIError)
 	ValidateAddress(ctx context.Context, request *address.ValidateReq) (*address.ValidateRes, *util.APIError)
 }
@@ -100,7 +102,7 @@ func (mc *MockClient) BytesToPDF(_ []byte) (*os.File, *util.APIError) {
 	return &os.File{}, nil
 }
 
-func (mc *MockClient) DownloadPDF(_ context.Context, _ string) (*letter.PDFRes, *util.APIError) {
+func (mc *MockClient) GetPDFContents(_ context.Context, pdfURL string) (*letter.PDFRes, *util.APIError) {
 	if mc.downloadPDFFailNext {
 		apiErr := util.BuildError(500, "downloadPDFFailNext is true")
 
@@ -116,9 +118,8 @@ func (mc *MockClient) DownloadPDF(_ context.Context, _ string) (*letter.PDFRes, 
 	}
 
 	return &letter.PDFRes{
-		Bytes: []byte("hi sean"),
-		Len:   len([]byte("hi sean")),
-		Name:  "hi sean.pdf",
+		Contents: io.NopCloser(bytes.NewBufferString(pdfURL)), // give the caller something to read if they want to
+		Name:     "hi sean.pdf",
 	}, nil
 }
 

--- a/stannp/mock.go
+++ b/stannp/mock.go
@@ -87,7 +87,7 @@ func (mc *MockClient) SendLetter(_ *letter.SendReq) (*letter.SendRes, *util.APIE
 			Created: util.RandomString(10),
 			Format:  util.RandomString(10),
 			Id:      "0",
-			Pdf:     util.RandomString(10),
+			PDF:     util.RandomString(10),
 			Status:  "received",
 		},
 		Success: true,

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -184,8 +184,8 @@ func TestMockDownloadPDF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := NewMockClient(tt.mockClientOptions...)
-			URL := util.RandomString(10)
-			downloadPDFRes, apiErr := mockClient.GetPDFContents(context.Background(), URL)
+			pdfURL := util.RandomString(10)
+			downloadPDFRes, apiErr := mockClient.GetPDFContents(context.Background(), pdfURL)
 
 			if tt.expectedError != nil {
 				assert.NotNil(t, apiErr)
@@ -195,7 +195,7 @@ func TestMockDownloadPDF(t *testing.T) {
 				assert.True(t, reflect.ValueOf(apiErr).IsNil())
 				assert.NotNil(t, downloadPDFRes)
 
-				assert.Equal(t, downloadPDFRes.Name, URL)
+				assert.Equal(t, downloadPDFRes.Name, pdfURL)
 
 				byteArray, err := io.ReadAll(downloadPDFRes.Contents)
 				assert.Nil(t, err)
@@ -203,7 +203,7 @@ func TestMockDownloadPDF(t *testing.T) {
 				err = downloadPDFRes.Contents.Close()
 				assert.Nil(t, err)
 
-				assert.Equal(t, len([]byte(URL)), len(byteArray))
+				assert.Equal(t, len([]byte(pdfURL)), len(byteArray))
 			}
 		})
 	}

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -249,7 +249,7 @@ func TestMockSendLetter(t *testing.T) {
 				assert.True(t, sendLetterRes.Data.Created != "")
 				assert.True(t, sendLetterRes.Data.Format != "")
 				assert.True(t, sendLetterRes.Data.Id == "0")
-				assert.True(t, sendLetterRes.Data.PDF != "")
+				assert.True(t, sendLetterRes.Data.PDFURL != "")
 				assert.True(t, sendLetterRes.Data.Status != "")
 			}
 		})

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -2,6 +2,7 @@ package stannp
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"testing"
 
@@ -183,7 +184,8 @@ func TestMockDownloadPDF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := NewMockClient(tt.mockClientOptions...)
-			downloadPDFRes, apiErr := mockClient.DownloadPDF(context.Background(), util.RandomString(10))
+			URL := util.RandomString(10)
+			downloadPDFRes, apiErr := mockClient.GetPDFContents(context.Background(), URL)
 
 			if tt.expectedError != nil {
 				assert.NotNil(t, apiErr)
@@ -194,9 +196,14 @@ func TestMockDownloadPDF(t *testing.T) {
 				assert.NotNil(t, downloadPDFRes)
 
 				assert.Equal(t, downloadPDFRes.Name, "hi sean.pdf")
-				//goland:noinspection GoRedundantConversion
-				assert.Equal(t, string(downloadPDFRes.Bytes), string([]byte("hi sean")))
-				assert.Equal(t, downloadPDFRes.Len, len([]byte("hi sean")))
+
+				byteArray, err := io.ReadAll(downloadPDFRes.Contents)
+				assert.Nil(t, err)
+
+				err = downloadPDFRes.Contents.Close()
+				assert.Nil(t, err)
+
+				assert.Equal(t, len([]byte(URL)), len(byteArray))
 			}
 		})
 	}

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -136,7 +136,7 @@ func TestMockBytesToPDF(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := NewMockClient(tt.mockClientOptions...)
-			localFile, apiErr := mockClient.BytesToPDF([]byte(util.RandomString(10)))
+			localFile, apiErr := mockClient.SavePDFContents(nil)
 
 			if tt.expectedError != nil {
 				assert.NotNil(t, apiErr)
@@ -195,7 +195,7 @@ func TestMockDownloadPDF(t *testing.T) {
 				assert.True(t, reflect.ValueOf(apiErr).IsNil())
 				assert.NotNil(t, downloadPDFRes)
 
-				assert.Equal(t, downloadPDFRes.Name, "hi sean.pdf")
+				assert.Equal(t, downloadPDFRes.Name, URL)
 
 				byteArray, err := io.ReadAll(downloadPDFRes.Contents)
 				assert.Nil(t, err)

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -51,11 +51,11 @@ func TestNewMockClient(t *testing.T) {
 			expect: MockClient{downloadPDFFailNext: true},
 		},
 		{
-			name: "with errNext",
+			name: "with errorMessageNext",
 			opts: []MockOption{
-				WithErrNext("error"),
+				WithErrorMessageNext("error"),
 			},
-			expect: MockClient{errNext: "error"},
+			expect: MockClient{errorMessageNext: "error"},
 		},
 		{
 			name: "with invalidNext",
@@ -78,7 +78,7 @@ func TestNewMockClient(t *testing.T) {
 				WithBytesToPDFFailNext(true),
 				WithCodeNext(400),
 				WithDownloadPDFFailNext(true),
-				WithErrNext("simulated error"),
+				WithErrorMessageNext("simulated error"),
 				WithInvalidNext(true),
 				WithLetterFailNext(true),
 			},
@@ -87,7 +87,7 @@ func TestNewMockClient(t *testing.T) {
 				bytesToPDFFailNext:  true,
 				codeNext:            400,
 				downloadPDFFailNext: true,
-				errNext:             "simulated error",
+				errorMessageNext:    "simulated error",
 				invalidNext:         true,
 				letterFailNext:      true,
 			},
@@ -125,7 +125,7 @@ func TestMockBytesToPDF(t *testing.T) {
 			name: "err expected code expected custom err expected",
 			mockClientOptions: []MockOption{
 				WithCodeNext(404),
-				WithErrNext("custom message"),
+				WithErrorMessageNext("custom message"),
 				WithBytesToPDFFailNext(true),
 			},
 			expectedSuccess: false,
@@ -173,7 +173,7 @@ func TestMockDownloadPDF(t *testing.T) {
 			name: "err expected code expected custom err expected",
 			mockClientOptions: []MockOption{
 				WithCodeNext(404),
-				WithErrNext("custom message"),
+				WithErrorMessageNext("custom message"),
 				WithDownloadPDFFailNext(true),
 			},
 			expectedSuccess: false,
@@ -232,7 +232,7 @@ func TestMockSendLetter(t *testing.T) {
 			name: "err expected code expected custom err expected",
 			mockClientOptions: []MockOption{
 				WithCodeNext(404),
-				WithErrNext("custom message"),
+				WithErrorMessageNext("custom message"),
 				WithLetterFailNext(true),
 			},
 			expectedSuccess: false,
@@ -296,7 +296,7 @@ func TestMockValidateAddress(t *testing.T) {
 			mockClientOptions: []MockOption{
 				WithAddressFailNext(true),
 				WithCodeNext(400),
-				WithErrNext("custom message"),
+				WithErrorMessageNext("custom message"),
 			},
 			isValidExpected: false,
 			errExpected:     util.BuildError(400, "custom message"),

--- a/stannp/mock_test.go
+++ b/stannp/mock_test.go
@@ -139,7 +139,7 @@ func TestMockSendLetter(t *testing.T) {
 				assert.True(t, sendLetterRes.Data.Created != "")
 				assert.True(t, sendLetterRes.Data.Format != "")
 				assert.True(t, sendLetterRes.Data.Id == "0")
-				assert.True(t, sendLetterRes.Data.Pdf != "")
+				assert.True(t, sendLetterRes.Data.PDF != "")
 				assert.True(t, sendLetterRes.Data.Status != "")
 			}
 		})

--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -152,7 +151,7 @@ func (s *Stannp) post(ctx context.Context, inputReader io.Reader, inputURL strin
 }
 
 func (s *Stannp) BytesToPDF(data []byte) (*os.File, *util.APIError) {
-	tmpFile, err := ioutil.TempFile("", "example.*.pdf")
+	tmpFile, err := os.CreateTemp("", "example.*.pdf")
 	if err != nil {
 		return nil, util.BuildError(500, err.Error())
 	}
@@ -198,7 +197,7 @@ func (s *Stannp) DownloadPDF(ctx context.Context, pdfURL string) (*letter.PDFRes
 		log.Fatal(err)
 	}
 
-	byteArray, err := ioutil.ReadAll(resp.Body)
+	byteArray, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, util.BuildError(500, err.Error())
 	}

--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -179,13 +179,13 @@ func (s *Stannp) GetPDFContents(ctx context.Context, pdfURL string) (*letter.PDF
 	}, nil
 }
 
-func (s *Stannp) SavePDFContents(data io.ReadCloser) (*os.File, *util.APIError) {
+func (s *Stannp) SavePDFContents(pdfContents io.ReadCloser) (*os.File, *util.APIError) {
 	tmpFile, err := os.CreateTemp("", "stannp_letter.*.pdf")
 	if err != nil {
 		return nil, util.BuildError(500, err.Error())
 	}
 
-	_, copyErr := io.Copy(tmpFile, data)
+	_, copyErr := io.Copy(tmpFile, pdfContents)
 	if copyErr != nil {
 		removeErr := os.Remove(tmpFile.Name())
 		if removeErr != nil {

--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -167,13 +167,12 @@ func (s *Stannp) BytesToPDF(data []byte) (*os.File, *util.APIError) {
 	return tmpFile, nil
 }
 
-func (s *Stannp) DownloadPDF(urlInput string) (*letter.PDFRes, *util.APIError) {
-	if !strings.HasPrefix(urlInput, PDFURLPrefix) {
-		return nil, util.BuildError(400, fmt.Sprintf("urlInput must begin with [%s]. your input was [%s]", PDFURLPrefix, urlInput))
+func (s *Stannp) DownloadPDF(pdfURL string) (*letter.PDFRes, *util.APIError) {
+	if !strings.HasPrefix(pdfURL, PDFURLPrefix) {
+		return nil, util.BuildError(400, fmt.Sprintf("pdfURL must begin with [%s]. your input was [%s]", PDFURLPrefix, pdfURL))
 	}
 
-	// Build fileName from fullPath
-	fileURL, err := url.Parse(urlInput)
+	fileURL, err := url.Parse(pdfURL)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -188,7 +187,7 @@ func (s *Stannp) DownloadPDF(urlInput string) (*letter.PDFRes, *util.APIError) {
 		},
 	}
 
-	resp, err := client.Get(urlInput)
+	resp, err := client.Get(pdfURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -150,6 +150,23 @@ func (s *Stannp) post(inputReader io.Reader, inputURL string) (*http.Response, *
 	return res, nil
 }
 
+func (s *Stannp) BytesToPDF(data []byte) (*os.File, *util.APIError) {
+	tmpFile, err := ioutil.TempFile("", "example.*.pdf")
+	if err != nil {
+		return nil, util.BuildError(500, err.Error())
+	}
+
+	if _, writeErr := tmpFile.Write(data); writeErr != nil {
+		closeErr := tmpFile.Close()
+		if closeErr != nil {
+			return nil, util.BuildError(500, closeErr.Error())
+		}
+		return nil, util.BuildError(500, writeErr.Error())
+	}
+
+	return tmpFile, nil
+}
+
 func (s *Stannp) DownloadPDF(urlInput string) (*letter.PDFRes, *util.APIError) {
 	if !strings.HasPrefix(urlInput, PDFURLPrefix) {
 		return nil, util.BuildError(400, fmt.Sprintf("urlInput must begin with [%s]. your input was [%s]", PDFURLPrefix, urlInput))
@@ -191,23 +208,6 @@ func (s *Stannp) DownloadPDF(urlInput string) (*letter.PDFRes, *util.APIError) {
 		Len:   len(byteArray),
 		Name:  fileName,
 	}, nil
-}
-
-func (s *Stannp) BytesToPDF(data []byte) (*os.File, error) {
-	tmpFile, err := ioutil.TempFile("", "example.*.pdf")
-	if err != nil {
-		return nil, err
-	}
-
-	if _, writeErr := tmpFile.Write(data); writeErr != nil {
-		closeErr := tmpFile.Close()
-		if closeErr != nil {
-			return nil, closeErr
-		}
-		return nil, writeErr
-	}
-
-	return tmpFile, nil
 }
 
 func (s *Stannp) SendLetter(request *letter.SendReq) (*letter.SendRes, *util.APIError) {

--- a/stannp/stannp.go
+++ b/stannp/stannp.go
@@ -179,7 +179,7 @@ func (s *Stannp) GetPDFContents(ctx context.Context, pdfURL string) (*letter.PDF
 	}, nil
 }
 
-func (s *Stannp) SavePDFContents(pdfContents io.ReadCloser) (*os.File, *util.APIError) {
+func (s *Stannp) SavePDFContents(pdfContents io.Reader) (*os.File, *util.APIError) {
 	tmpFile, err := os.CreateTemp("", "stannp_letter.*.pdf")
 	if err != nil {
 		return nil, util.BuildError(500, err.Error())

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/jgroeneveld/trial/assert"
 	"github.com/joho/godotenv"
-	"io"
 	"log"
 	"os"
 	"reflect"
@@ -120,13 +119,7 @@ func TestSendLetterAndDownloadPDFAndBytesToPDF(t *testing.T) {
 	pdfRes, apiErr := TestClient.GetPDFContents(context.Background(), response.Data.PDFURL)
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 
-	byteArray, err := io.ReadAll(pdfRes.Contents)
-	assert.Nil(t, err)
-
-	err = pdfRes.Contents.Close()
-	assert.Nil(t, err)
-
-	fileRes, fileErr := TestClient.BytesToPDF(byteArray)
+	fileRes, fileErr := TestClient.SavePDFContents(pdfRes.Contents)
 	assert.True(t, reflect.ValueOf(fileErr).IsNil())
 	defer func() {
 		removeErr := os.Remove(fileRes.Name())
@@ -138,8 +131,8 @@ func TestSendLetterAndDownloadPDFAndBytesToPDF(t *testing.T) {
 	content, err := os.ReadFile(fileRes.Name())
 	assert.Nil(t, err)
 
-	// Compare the length of the original data with the read content
-	assert.Equal(t, len(byteArray), len(content))
+	// Compare the length of the original data versus the expected return result to see if the PDF changed
+	assert.Equal(t, 624896, len(content))
 }
 
 func TestValidateAddress(t *testing.T) {

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 	// Load .env file
 	err := godotenv.Load("../.env")
 	if err != nil {
-		t.Fatal("Error loading .env file")
+		t.Fatal("error loading .env file")
 	}
 
 	// Get API key from environment variable

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/jgroeneveld/trial/assert"
 	"github.com/joho/godotenv"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -121,9 +120,14 @@ func TestSendLetterAndDownloadPDFAndBytesToPDF(t *testing.T) {
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 	fileRes, fileErr := TestClient.BytesToPDF(pdfRes.Bytes)
 	assert.True(t, reflect.ValueOf(fileErr).IsNil())
-	defer os.Remove(fileRes.Name())
+	defer func() {
+		removeErr := os.Remove(fileRes.Name())
+		if removeErr != nil {
+			t.FailNow()
+		}
+	}()
 
-	content, err := ioutil.ReadFile(fileRes.Name())
+	content, err := os.ReadFile(fileRes.Name())
 	if err != nil {
 		t.Fatalf("ReadFile failed: %s", err)
 	}

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -114,9 +114,9 @@ func TestSendLetterAndDownloadPDFAndBytesToPDF(t *testing.T) {
 	assert.Equal(t, response.Data.Status, "test")
 	assert.True(t, response.Success)
 	assert.True(t, strings.HasPrefix(response.Data.Created, dateString))
-	assert.True(t, strings.HasPrefix(response.Data.PDF, "https://us.stannp.com/api/v1/storage/get/"))
+	assert.True(t, strings.HasPrefix(response.Data.PDFURL, "https://us.stannp.com/api/v1/storage/get/"))
 
-	pdfRes, apiErr := TestClient.DownloadPDF(response.Data.PDF)
+	pdfRes, apiErr := TestClient.DownloadPDF(response.Data.PDFURL)
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 	fileRes, fileErr := TestClient.BytesToPDF(pdfRes.Bytes)
 	assert.True(t, reflect.ValueOf(fileErr).IsNil())

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -119,7 +119,7 @@ func TestSendLetterAndDownloadPDFAndBytesToPDF(t *testing.T) {
 	pdfRes, apiErr := TestClient.DownloadPDF(response.Data.PDF)
 	assert.True(t, reflect.ValueOf(apiErr).IsNil())
 	fileRes, fileErr := TestClient.BytesToPDF(pdfRes.Bytes)
-	assert.Nil(t, fileErr)
+	assert.True(t, reflect.ValueOf(fileErr).IsNil())
 	defer os.Remove(fileRes.Name()) // clean up
 
 	// Read the file's content

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -2,6 +2,7 @@ package stannp
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/CopilotIQ/stannp-client-golang/address"
 	"github.com/CopilotIQ/stannp-client-golang/letter"
 	"github.com/jgroeneveld/trial/assert"
@@ -84,7 +85,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, 36, len(api.idemFunc()))
 }
 
-func TestSendLetter(t *testing.T) {
+func TestSendLetterAndDownloadPDF(t *testing.T) {
 	// Call SendLetter with a new instance of SendReq
 	request := &letter.SendReq{
 		Template: "307051",
@@ -107,13 +108,18 @@ func TestSendLetter(t *testing.T) {
 
 	dateString := time.Now().Format("2006-01-02")
 
-	assert.Equal(t, response.Data.Cost, "0.81")
+	assert.Equal(t, response.Data.Cost, "0.84")
 	assert.Equal(t, response.Data.Format, "US-LETTER")
 	assert.Equal(t, response.Data.Id.String(), "0")
 	assert.Equal(t, response.Data.Status, "test")
 	assert.True(t, response.Success)
 	assert.True(t, strings.HasPrefix(response.Data.Created, dateString))
-	assert.True(t, strings.HasPrefix(response.Data.Pdf, "https://us.stannp.com/api/v1/storage/get/"))
+	assert.True(t, strings.HasPrefix(response.Data.PDF, "https://us.stannp.com/api/v1/storage/get/"))
+
+	fmt.Println(fmt.Sprintf("response.Data.PDF is [%s]", response.Data.PDF))
+
+	pdfRes, apiErr := TestClient.DownloadPDF(response.Data.PDF)
+	fmt.Println(fmt.Sprintf("pdfRes is [%+v]", pdfRes))
 }
 
 func TestValidateAddress(t *testing.T) {

--- a/stannp/stannp_test.go
+++ b/stannp/stannp_test.go
@@ -136,7 +136,7 @@ func TestStannp(t *testing.T) {
 				assert.Nil(t, err)
 
 				// Compare the length of the original data versus the expected return result to see if the PDF changed
-				assert.Equal(t, 624896, len(content))
+				assert.Equal(t, 624899, len(content))
 			})
 		})
 	})

--- a/util/util.go
+++ b/util/util.go
@@ -18,11 +18,11 @@ func (apiError *APIError) String() string {
 	return fmt.Sprintf("Stannp Client API Error: Code [%d] Success [%t] Error [%s]", apiError.Code, apiError.Success, apiError.Error)
 }
 
-func BuildError(code int, errorMessage string, success bool) *APIError {
+func BuildError(code int, errorMessage string) *APIError {
 	return &APIError{
 		Code:    code,
 		Error:   errorMessage,
-		Success: success,
+		Success: false,
 	}
 }
 
@@ -44,12 +44,12 @@ func RandomString(n int) string {
 
 func ResToType(code int, reader io.Reader, successType interface{}) *APIError {
 	if code < http.StatusOK || (code < http.StatusBadRequest && code >= http.StatusMultipleChoices) {
-		return BuildError(500, fmt.Sprintf("unexpected status code [%d]", code), false)
+		return BuildError(500, fmt.Sprintf("unexpected status code [%d]", code))
 	}
 
 	resBody, err := io.ReadAll(reader)
 	if err != nil {
-		return BuildError(500, fmt.Sprintf("error reading response body [%+v] with err [%+v]", string(resBody), err), false)
+		return BuildError(500, fmt.Sprintf("error reading response body [%+v] with err [%+v]", string(resBody), err))
 	}
 
 	var jsonErr error
@@ -64,7 +64,7 @@ func ResToType(code int, reader io.Reader, successType interface{}) *APIError {
 	}
 
 	if jsonErr != nil {
-		return BuildError(500, fmt.Sprintf("error unmarshalling res [%+v]", string(resBody)), false)
+		return BuildError(500, fmt.Sprintf("error unmarshalling res [%+v]", string(resBody)))
 	}
 
 	if doReturnError {

--- a/util/util.go
+++ b/util/util.go
@@ -9,20 +9,24 @@ import (
 )
 
 type APIError struct {
-	Code    int    `json:"code"`
-	Error   string `json:"error"`
-	Success bool   `json:"success"`
+	Code         int    `json:"code"`
+	ErrorMessage string `json:"error"`
+	Success      bool   `json:"success"`
+}
+
+func (apiError *APIError) Error() string {
+	return fmt.Sprintf("Code [%d] ErrorMessage [%s] Success [%t]", apiError.Code, apiError.ErrorMessage, apiError.Success)
 }
 
 func (apiError *APIError) String() string {
-	return fmt.Sprintf("Stannp Client API Error: Code [%d] Success [%t] Error [%s]", apiError.Code, apiError.Success, apiError.Error)
+	return fmt.Sprintf("Stannp Client API ErrorMessage: Code [%d] Success [%t] ErrorMessage [%s]", apiError.Code, apiError.Success, apiError.ErrorMessage)
 }
 
 func BuildError(code int, errorMessage string) *APIError {
 	return &APIError{
-		Code:    code,
-		Error:   errorMessage,
-		Success: false,
+		Code:         code,
+		ErrorMessage: errorMessage,
+		Success:      false,
 	}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -19,7 +19,7 @@ func (apiError *APIError) Error() string {
 }
 
 func (apiError *APIError) String() string {
-	return fmt.Sprintf("Stannp Client API ErrorMessage: Code [%d] Success [%t] ErrorMessage [%s]", apiError.Code, apiError.Success, apiError.ErrorMessage)
+	return fmt.Sprintf("Stannp Client APIError: Code [%d] Success [%t] ErrorMessage [%s]", apiError.Code, apiError.Success, apiError.ErrorMessage)
 }
 
 func BuildError(code int, errorMessage string) *APIError {
@@ -57,11 +57,9 @@ func ResToType(code int, reader io.Reader, successType interface{}) *APIError {
 	}
 
 	var jsonErr error
-	var doReturnError bool
-	var serverErr APIError
+	var serverErr *APIError
 	if code >= http.StatusBadRequest {
-		doReturnError = true
-		jsonErr = json.Unmarshal(resBody, &serverErr)
+		jsonErr = json.Unmarshal(resBody, serverErr)
 		serverErr.Code = code
 	} else {
 		jsonErr = json.Unmarshal(resBody, &successType)
@@ -71,9 +69,5 @@ func ResToType(code int, reader io.Reader, successType interface{}) *APIError {
 		return BuildError(500, fmt.Sprintf("error unmarshalling res [%+v]", string(resBody)))
 	}
 
-	if doReturnError {
-		return &serverErr
-	}
-
-	return nil
+	return serverErr
 }


### PR DESCRIPTION
1. Implement downloading the PDF url from the letter response
2. Implement saving the PDF bytes to a local PDF file
3. Light to medium refactoring across the board for the Client interface, the tests, and util functions.